### PR TITLE
Added XRootD read time into the debug log and modified code for debug…

### DIFF
--- a/ch/cern/eos/DebugLogger.java
+++ b/ch/cern/eos/DebugLogger.java
@@ -21,7 +21,7 @@ import org.apache.log4j.Logger;
 
 public class DebugLogger {
 
-    private Logger logger = LogManager.getRootLogger();
+    private Logger logger = LogManager.getLogger("HadoopXRootD");
     
     public DebugLogger(boolean debugEnabled) {
         this.setDebug(debugEnabled);

--- a/ch/cern/eos/DebugLogger.java
+++ b/ch/cern/eos/DebugLogger.java
@@ -51,7 +51,9 @@ public class DebugLogger {
     }
 
     public void setDebug(boolean debugEnabled) {
-	this.logger.setLevel(debugEnabled ? Level.DEBUG : Level.INFO);
+        if (debugEnabled) {
+            this.logger.setLevel(Level.DEBUG);
+        }
     }
     
     public boolean isDebugEnabled() {

--- a/ch/cern/eos/XrootDBasedInputStream.java
+++ b/ch/cern/eos/XrootDBasedInputStream.java
@@ -72,8 +72,11 @@ class XrootDBasedInputStream extends FSInputStream implements Seekable, Position
             return (int)this.pos;
         }
 
+        long startTime = System.nanoTime();
         long rd = file.Read(pos, b, off, len);
+        long endTime = System.nanoTime();
         this.eosDebugLogger.printDebug("EOSInputStream.read(pos=" + pos + ", b, off=" + off + ", len=" + len + ") readBytes: " + rd);
+        this.eosDebugLogger.printDebug("EOSInputStream read operation elapsed time=" + (endTime - startTime)/1000 + " microsec");
         if (rd >= 0) {
             this.pos = pos + rd;
             updateStatsBytesRead(rd);


### PR DESCRIPTION
Added XRootD read time into the debug log
Modified code for debug log not to change the log level is EOS_debug is not set (previously the code would se loglevel to INFO if debug was not set)