### PR TITLE
Added XRootDInstrumentation class and read time elapsed metric.

### DIFF
--- a/ch/cern/eos/XRootDInstrumentation.java
+++ b/ch/cern/eos/XRootDInstrumentation.java
@@ -1,0 +1,18 @@
+package ch.cern.eos;
+
+public class XRootDInstrumentation {
+
+    private static Long timeElapsedReadOps = 0L;
+
+    public void incrementTimeElapsedReadOps(Long incrementTime) {
+        timeElapsedReadOps += incrementTime;
+    }
+
+    // This is a public and static method so it can be read from clients calling
+    // ch.cern.eos.XRootDInstrumentation.getTimeElapsedReadOps()
+    public static long getTimeElapsedReadOps() {
+        return timeElapsedReadOps;
+    }
+
+}
+

--- a/ch/cern/eos/XRootDInstrumentation.java
+++ b/ch/cern/eos/XRootDInstrumentation.java
@@ -1,15 +1,42 @@
+/*
+ * Copyright 2014-2022 CERN IT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ch.cern.eos;
 
 public class XRootDInstrumentation {
 
     private static Long timeElapsedReadOps = 0L;
 
+    /**
+     * Increment the value of the cumulative elapsed time spent  by
+     * Hadoop Filesystem clients waiting for EOS to return data of read
+     * operations. The time is in microseconds.
+     * @param incrementTime the time to add to the cumulative value, in microseconds
+     */
     public void incrementTimeElapsedReadOps(Long incrementTime) {
         timeElapsedReadOps += incrementTime;
     }
 
-    // This is a public and static method so it can be read from clients calling
-    // ch.cern.eos.XRootDInstrumentation.getTimeElapsedReadOps()
+    /**
+     * Get the cumulative value of the elapsed time spent  by
+     * Hadoop Filesystem clients waiting for EOS to return data of read
+     * operations. The time is in microseconds.
+     * Use from Hadoop clients, such as Spark environments, by calling
+     * ch.cern.eos.XRootDInstrumentation.getTimeElapsedReadOps()
+     * @return cumulative elapsed read time in microseconds.
+     */
     public static long getTimeElapsedReadOps() {
         return timeElapsedReadOps;
     }

--- a/ch/cern/eos/XrootDBasedFileSystem.java
+++ b/ch/cern/eos/XrootDBasedFileSystem.java
@@ -218,9 +218,12 @@ public class XrootDBasedFileSystem extends FileSystem {
 		URI u = toUri(path);
 		String filespec = uri.getScheme() + "://" +  uri.getAuthority() + "/" + u.getPath();
 
+		// create object for extra instrumentation of metrics
+		XRootDInstrumentation instrumentation = new XRootDInstrumentation();
+
 		// ReadAhead is done with BufferedFSInputStream
 		eosDebugLogger.printDebug("EOSfs open " + filespec + " with readAhead=" + readAhead);
-		return new FSDataInputStream(new BufferedFSInputStream(new XrootDBasedInputStream(filespec, statistics),readAhead));
+		return new FSDataInputStream(new BufferedFSInputStream(new XrootDBasedInputStream(filespec, statistics, instrumentation),readAhead));
     }
 
     public FileStatus getFileStatus(Path p) throws IOException {

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ CXXFLAGS=-I$(INCLxrootd) -I$(INCLjava) -I$(INCLjava)/linux -fPIC
 
 export CLASSPATH=$(shell hadoop classpath) 
 
-CLASSES = ch/cern/eos/XrootDBasedClFile.java ch/cern/eos/Krb5TokenIdentifier.java ch/cern/eos/XrootDBasedFileSystem.java ch/cern/eos/XrootDBasedKerberizedFileSystem.java ch/cern/eos/XrootDBasedInputStream.java ch/cern/eos/XrootDBasedOutputStream.java ch/cern/eos/XrootDBasedKrb5.java ch/cern/eos/Krb5TokenRenewer.java ch/cern/eos/DebugLogger.java ch/cern/eos/XRootDUtils.java ch/cern/eos/XRootDConstants.java
+CLASSES = ch/cern/eos/XrootDBasedClFile.java ch/cern/eos/Krb5TokenIdentifier.java ch/cern/eos/XrootDBasedFileSystem.java ch/cern/eos/XrootDBasedKerberizedFileSystem.java ch/cern/eos/XrootDBasedInputStream.java ch/cern/eos/XrootDBasedOutputStream.java ch/cern/eos/XrootDBasedKrb5.java ch/cern/eos/Krb5TokenRenewer.java ch/cern/eos/DebugLogger.java ch/cern/eos/XRootDUtils.java ch/cern/eos/XRootDConstants.java ch/cern/eos/XRootDInstrumentation.java
 
 all: libjXrdCl.so EOSfs.jar
 


### PR DESCRIPTION
This change introduces the XRootDInstrumentation which is used to track the read time elapsed metric.
This work around the problem that this metric cannot go into the vanilla Hadoop filesystem statistics.

The way to consume the metric is simply to call the (public static) method ch.cern.eos.XRootDInstrumentation.getTimeElapsedReadOps() 

Ideas for future development and extensions of this work:
- augment this class with more metrics
- introduce more methods, for example a method for building histograms of the read time (useful to debug skew and straggler issues)
- export the metrics with Hadoop metrics2 and/or dropwizard
